### PR TITLE
Remove WEX as street price provider

### DIFF
--- a/Sentinel/Core/API/StreetPrices/StreetPricesProvider.swift
+++ b/Sentinel/Core/API/StreetPrices/StreetPricesProvider.swift
@@ -10,7 +10,6 @@ import Moya
 
 enum StreetPrice {
     case localbitcoins
-    case wex(currency: String)
     case bitfinex
 }
 
@@ -20,8 +19,6 @@ extension StreetPrice: TargetType {
         switch self {
         case .localbitcoins:
             return URL(string: "https://localbitcoins.com/bitcoinaverage/ticker-all-currencies/")!
-        case .wex(let currency):
-            return URL(string: "https://wex.nz/api/3/ticker/btc_\(currency.lowercased())")!
         case .bitfinex:
             return URL(string: "https://api.bitfinex.com/v1/pubticker/btcusd")!
         }

--- a/Sentinel/Core/Sentinel/Sentinel.swift
+++ b/Sentinel/Core/Sentinel/Sentinel.swift
@@ -361,8 +361,6 @@ extension Sentinel {
             
             var provider: StreetPrice
             switch providerStr {
-            case "WEX":
-                provider = .wex(currency: currencyStr)
             case "Bitfinex":
                 provider = .bitfinex
             default:
@@ -376,11 +374,6 @@ extension Sentinel {
                         guard let currencyDic = json[currencyStr] as? [String: Any] else { seal.reject(Errors.noPrice); return }
                         guard let average = currencyDic["avg_12h"] as? String else { seal.reject(Errors.noPrice); return }
                         _ = UserDefaults.standard.set(Double(average), forKey: "Price")
-                        seal.fulfill(())
-                    }else if providerStr == "WEX" {
-                        guard let currencyDic = json["btc_\(currencyStr.lowercased())"] as? [String: Any] else { seal.reject(Errors.noPrice); return }
-                        guard let average = currencyDic["avg"] as? Double else { seal.reject(Errors.noPrice); return }
-                        _ = UserDefaults.standard.set(average, forKey: "Price")
                         seal.fulfill(())
                     }else{
                         guard let average = json["mid"] as? String else { seal.reject(Errors.noPrice); return }

--- a/Sentinel/UI/VC/StreetPrice/StreetPriceViewController.swift
+++ b/Sentinel/UI/VC/StreetPrice/StreetPriceViewController.swift
@@ -16,10 +16,8 @@ class StreetPriceViewController: UIViewController {
     @IBOutlet var streetPriceTableView: UITableView!
     
     let exchanges = ["Localbitcoins.com",
-                     "WEX",
                      "Bitfinex"]
     let currencies = [["USD", "EUR", "GBP", "CNY", "RUR"],
-                      ["USD", "EUR", "RUR"],
                       ["USD"]]
     
     init(sentinel: Sentinel) {


### PR DESCRIPTION
I guess wex.nz can be removed as a street price provider since it doesn't exist anymore.

Before:
![Simulator Screen Shot - iPhone 8 Plus - 2020-04-17 at 09 33 04](https://user-images.githubusercontent.com/109058/79545234-a760b400-8090-11ea-9ee6-278be26c91cb.png)

After:
![Simulator Screen Shot - iPhone 8 Plus - 2020-04-17 at 09 39 54](https://user-images.githubusercontent.com/109058/79545251-acbdfe80-8090-11ea-8635-1fa795551425.png)

Will rebase the PR and submit it upstream once https://github.com/Samourai-Wallet/Sentinel-iOS/pull/9 is merged to develop.