### PR TITLE
Upgrade to Moya 14 / Alamofire 5

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -9,7 +9,7 @@ target 'Sentinel' do
   # Pods for Sentinel
   pod 'PromiseKit', '~> 6.2.8'
   pod 'CryptoSwift', '~> 0.10.0'
-  pod 'Moya', '~> 11.0.2'
+  pod 'Moya', '~> 14.0.0'
   pod 'secp256k1.swift', '~> 0.1.4'
   pod 'SwiftRichString', '~> 2.0.1'
   pod 'lottie-ios', '~> 2.5.0'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,16 +1,15 @@
 PODS:
-  - Alamofire (4.7.2)
+  - Alamofire (5.1.0)
   - CryptoSwift (0.10.0)
   - HDWalletKit (0.1.1):
     - CryptoSwift (~> 0.10.0)
     - secp256k1.swift (~> 0.1.4)
   - Locksmith (4.0.0)
   - lottie-ios (2.5.0)
-  - Moya (11.0.2):
-    - Moya/Core (= 11.0.2)
-  - Moya/Core (11.0.2):
-    - Alamofire (~> 4.1)
-    - Result (~> 3.0)
+  - Moya (14.0.0):
+    - Moya/Core (= 14.0.0)
+  - Moya/Core (14.0.0):
+    - Alamofire (~> 5.0)
   - PromiseKit (6.2.8):
     - PromiseKit/CorePromise (= 6.2.8)
     - PromiseKit/Foundation (= 6.2.8)
@@ -27,7 +26,6 @@ PODS:
   - Realm/Headers (3.20.0)
   - RealmSwift (3.20.0):
     - Realm (= 3.20.0)
-  - Result (3.2.4)
   - secp256k1.swift (0.1.4)
   - Starscream (3.0.5)
   - SwiftRichString (2.0.1)
@@ -37,7 +35,7 @@ DEPENDENCIES:
   - HDWalletKit (from `https://github.com/Samourai-Wallet/HDWalletKit.git`, commit `bfedd45259d61d8de9465f91e14f1322e79cdf81`)
   - Locksmith (~> 4.0.0)
   - lottie-ios (~> 2.5.0)
-  - Moya (~> 11.0.2)
+  - Moya (~> 14.0.0)
   - PromiseKit (~> 6.2.8)
   - QRCodeReader.swift (~> 8.2.0)
   - ReachabilitySwift (~> 4.1.0)
@@ -48,19 +46,18 @@ DEPENDENCIES:
 
 SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
-    - Alamofire
     - CryptoSwift
     - Locksmith
     - lottie-ios
-    - Moya
     - PromiseKit
     - QRCodeReader.swift
     - ReachabilitySwift
-    - Result
     - secp256k1.swift
     - Starscream
     - SwiftRichString
   trunk:
+    - Alamofire
+    - Moya
     - Realm
     - RealmSwift
 
@@ -75,22 +72,21 @@ CHECKOUT OPTIONS:
     :git: https://github.com/Samourai-Wallet/HDWalletKit.git
 
 SPEC CHECKSUMS:
-  Alamofire: e4fa87002c137ba2d8d634d2c51fabcda0d5c223
+  Alamofire: 9d5c5f602928e512395b30950c5984eca840093c
   CryptoSwift: 6c778d69282bed3b4e975ff97a79d074f20bb011
   HDWalletKit: 6ee3b97f4565f052e6739ba26749e2002782d0e2
   Locksmith: e9bebbaaa4cee3c511bc358a44f843c3fe00e21f
   lottie-ios: d699fdee68d7b63e721d949388b015fef1aaa4ac
-  Moya: a725035953bc1c0eb1be505ab903984501d82440
+  Moya: 5b45dacb75adb009f97fde91c204c1e565d31916
   PromiseKit: 6788ce1a0ed5448b83d4aaf56b9fc49fb7647d32
   QRCodeReader.swift: 003eb32f18a5a675b936ec82ba0ff368cddbff45
   ReachabilitySwift: 6849231cd4e06559f3b9ef4a97a0a0f96d41e09f
   Realm: 8b2ca5bc6479a91f379b6b42b5922e396cd5ba5a
   RealmSwift: 1949ef26a279e1845bd51d591b9103adfcd121df
-  Result: d2d07204ce72856f1fd9130bbe42c35a7b0fea10
   secp256k1.swift: a7e7a214f6db6ce5db32cc6b2b45e5c4dd633634
   Starscream: faf918b2f2eff7d5dd21180646bf015a669673bd
   SwiftRichString: 3b29b5f2eb0eb244497532f2fd2ec26318eae584
 
-PODFILE CHECKSUM: 2b80b752d62fb9adc141f6233d1e71b6fbfc3bb3
+PODFILE CHECKSUM: a13ecc1d1a7ed15be59cb0f511f12f6c0d2fe9fd
 
 COCOAPODS: 1.9.1

--- a/Sentinel/UI/VC/PushTX/PushTXViewController.swift
+++ b/Sentinel/UI/VC/PushTX/PushTXViewController.swift
@@ -47,11 +47,11 @@ class PushTXViewController: UIViewController {
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         
         request.httpBody = "tx=\(textView.text!)".data(using: .utf8)!
-        Alamofire.request(request).responseJSON { (response) in
+        AF.request(request).responseJSON { (response) in
             
-            guard response.result.error == nil else {
+            guard response.error == nil else {
                 self.navigationItem.rightBarButtonItem?.isEnabled = true
-                self.alert(title: "Error", message: "Failed to push the transaction. \(response.result.error!.localizedDescription)", close: "OK!")
+                self.alert(title: "Error", message: "Failed to push the transaction. \(response.error!.localizedDescription)", close: "OK!")
                 return
             }
             
@@ -61,7 +61,7 @@ class PushTXViewController: UIViewController {
                 return
             }
             
-            guard let json = response.result.value as? [String: Any] else {
+            guard let json = response.value as? [String: Any] else {
                 self.navigationItem.rightBarButtonItem?.isEnabled = true
                 return
             }


### PR DESCRIPTION
Moya 14.0.0 includes Alamofire 5.1.0.

This upgrade paves the way for a seamless Tor integration. The changes in Alamofire make working with custom `NSURLSessions` easier. See changes to `SessionManager` (now `Session`) in the [Alamofire docs](https://github.com/Alamofire/Alamofire/blob/master/Documentation/Alamofire%205.0%20Migration%20Guide.md#benefits-of-upgrading).

Adjustments due to breaking changes are minimal in Sentinel. See fb69f49 