### PR TITLE
Refactor PushTx network code to use Moya

### DIFF
--- a/Sentinel/Core/API/Samourai/SamouraiProvider.swift
+++ b/Sentinel/Core/API/Samourai/SamouraiProvider.swift
@@ -15,6 +15,7 @@ enum Samourai {
     case xpub(xpub: String)
     case addxpub(xpub: String, type: String, segwit: String?)
     case tx(txid: String)
+    case pushtx(tx: String)
     case header(hash: String)
     case fees
 }
@@ -37,6 +38,8 @@ extension Samourai: TargetType {
             return "xpub/"
         case .tx(let txid):
             return "tx/\(txid)"
+        case .pushtx:
+            return "pushtx"
         case .header(let hash):
             return "header/\(hash)"
         case .fees:
@@ -47,6 +50,8 @@ extension Samourai: TargetType {
     var method: Moya.Method {
         switch self {
         case .addxpub:
+            return .post
+        case .pushtx:
             return .post
         default:
             return .get
@@ -63,6 +68,8 @@ extension Samourai: TargetType {
             return .requestParameters(parameters: parameters(active: active, new: new, bip49: bip49, bip84: bip84), encoding: URLEncoding.default)
         case let .addxpub(xpub, type, segwit):
             return .requestParameters(parameters: parameters(xpub: xpub, type: type, segwit: segwit), encoding: URLEncoding.default)
+        case let .pushtx(tx):
+            return .requestParameters(parameters: ["tx": tx], encoding: JSONEncoding.default)
         default:
             return .requestPlain
         }

--- a/Sentinel/UI/VC/PushTX/PushTXViewController.swift
+++ b/Sentinel/UI/VC/PushTX/PushTXViewController.swift
@@ -7,7 +7,7 @@
 //
 
 import UIKit
-import Alamofire
+import Moya
 import QRCodeReader
 
 class PushTXViewController: UIViewController {
@@ -42,31 +42,26 @@ class PushTXViewController: UIViewController {
             return
         }
         
-        var request = URLRequest(url: URL(string: "https://api.samouraiwallet.com/v2/pushtx/")!)
-        request.httpMethod = HTTPMethod.post.rawValue
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        guard let rawTx = textView.text else {
+            return
+        }
         
-        request.httpBody = "tx=\(textView.text!)".data(using: .utf8)!
-        AF.request(request).responseJSON { (response) in
-            
-            guard response.error == nil else {
-                self.navigationItem.rightBarButtonItem?.isEnabled = true
-                self.alert(title: "Error", message: "Failed to push the transaction. \(response.error!.localizedDescription)", close: "OK!")
-                return
+        let samouraiAPI = MoyaProvider<Samourai>()
+        samouraiAPI.request(.pushtx(tx: rawTx)) { result in
+            switch result {
+            case let .success(moyaResponse):
+                let statusCode = moyaResponse.statusCode
+                
+                switch statusCode {
+                case 200:
+                    self.alert(title: "Done", message: "Transaction pushed successfully.", close: "OK", action: self.close)
+                default:
+                    self.alert(title: "Info", message: "Something went wrong. HTTP \(statusCode)", close: "OK")
+                }
+            case let .failure(error):
+                self.alert(title: "Error", message: "Failed to push the transaction. \(error.localizedDescription)", close: "OK")
             }
             
-            guard !(response.response?.statusCode == 200) else {
-                self.navigationItem.rightBarButtonItem?.isEnabled = true
-                self.alert(title: "Done", message: "Transaction pushed successfully.", close: "OK", action: self.close)
-                return
-            }
-            
-            guard let json = response.value as? [String: Any] else {
-                self.navigationItem.rightBarButtonItem?.isEnabled = true
-                return
-            }
-
-            self.alert(title: "Error", message: "Failed to push the transaction. \(json["error"] ?? "Unkown error")", close: "OK")
             self.navigationItem.rightBarButtonItem?.isEnabled = true
         }
     }


### PR DESCRIPTION
Using `SamouraiAPI` and the existing Samourai MoyaProvider streamlines the code and eliminates duplicate code (most importantly the endpoint definition). Will make using a different endpoint (🧅) for all API calls easier.

Note: Having the possibility to use testnet for `DEBUG` builds would be great. It would make testing easier and less expensive. A comprehensive test suite would be awesome as well, but I'll have to give that some thought. Some things might be challenging to test properly in an automatic fashion.